### PR TITLE
Add support for custom Nova guard.

### DIFF
--- a/src/Models/NovaSentMail.php
+++ b/src/Models/NovaSentMail.php
@@ -54,7 +54,7 @@ class NovaSentMail extends Model
      */
     public function sender()
     {
-        return $this->belongsTo(config('auth.providers.users.model'));
+        return $this->belongsTo(config('auth.providers.'. config('nova.guard') .'.model'));
     }
 
     /**


### PR DESCRIPTION
This fixes "Class name must be a valid object or a string error" error when using custom Nova authentication guard.